### PR TITLE
Build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,5 +13,16 @@ jobs:
       - name: "install Nix"
         uses: "cachix/install-nix-action@v12"
 
+      - name: "use IHP cache"
+        uses: cachix/cachix-action@v10
+        with:
+          name: digitallyinduced
+
       - name: "build doorgeefluik"
         run: "nix-build"
+        # IHP expects <nixpkgs> to be present, so we set it to a release
+        # IHP doesn't actually use this, so it doesn't really matter which release this is
+        # see: https://github.com/digitallyinduced/ihp/blob/edca5f0b61b499cb214441ca2826affd5cb04563/NixSupport/make-nixpkgs-from-options.nix#L74
+        env:
+          NIX_PATH: nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-21.05.tar.gz
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,12 @@ jobs:
       - name: "install Nix"
         uses: "cachix/install-nix-action@v12"
 
-      - name: "use IHP cache"
+      - name: "use project cache (pull and push) and IHP cache (pull only)"
         uses: cachix/cachix-action@v10
         with:
-          name: digitallyinduced
+          name: svsticky-doorgeefluik
+          authToken: ${{ secrets.CACHIX_API_KEY }}
+          extraPullNames: digitallyinduced
 
       - name: "build doorgeefluik"
         run: "nix-build"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+---
+name: "Build"
+on:
+  "pull_request"
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - name: "install Nix"
+        uses: "cachix/install-nix-action@v12"
+
+      - name: "build doorgeefluik"
+        run: "nix-build"


### PR DESCRIPTION
This builds doorgeefluik in CI.
The end goal is to push the build artifacts to cachix, so we can `nix-instantiate` the build on the server as a means of deploying.

TODO
 - [x] Create a cachix cache for this project and link it in CI
 - [x] Run tests and linters in CI (update: there are no tests and hlint doesn't succeed yet)
 
 Builds don't seem to be completely reproducible yet, I get different derivation paths in CI compared to local. We probably need to ignore some files in the src variable to get this fixed, I'm looking into this